### PR TITLE
Incorporate settle spread to compute fill amounts

### DIFF
--- a/lib/computeBuySellData.js
+++ b/lib/computeBuySellData.js
@@ -2,7 +2,7 @@ const BN = require('./BN')
 const splitSymbol = require('./splitSymbol')
 const toBN = require('./toBN')
 
-module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRate, computeFill }) => {
+module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRate, settleSpreadBuy, settleSpreadSell }) => {
   amount = toBN(amount)
   price = toBN(price)
 
@@ -29,37 +29,11 @@ module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRa
   const sellTokenReg = getTokenInfo(sell.token)
   const buyTokenReg = getTokenInfo(buy.token)
 
-  // If Buy and Sell Amounts are for fill then first calculate
-  // the original order settle spread and use the same to calculate
-  // buy and sell amounts for the fill
-  if (computeFill) {
-    const orderBuyAmount = computeFill.amountBuy
-    const orderSellAmount = computeFill.amountSell
-
-    const buySettleSpread = toBN(orderBuyAmount)
-      .times(buyTokenReg.quantization)
-      .shiftedBy(-1 * buyTokenReg.decimals)
-      .dividedBy(buy.amount)
-      .dividedBy(1 - feeRate)
-      .minus(1)
-      .toNumber()
-
-    buyTokenReg.settleSpread = buySettleSpread
-
-    const sellSettleSpread = toBN(orderSellAmount)
-      .times(sellTokenReg.quantization)
-      .shiftedBy(-1 * sellTokenReg.decimals)
-      .dividedBy(sell.amount)
-      .minus(1)
-      .toNumber()
-
-    sellTokenReg.settleSpread = sellSettleSpread
-  }
   const amountBuy = toBN(10)
     .pow(buyTokenReg.decimals)
     .times(buy.amount)
     .dividedBy(buyTokenReg.quantization)
-    .times(1 + (buyTokenReg.settleSpread || 0))
+    .times(1 + (settleSpreadBuy || 0))
     .times(1 - feeRate)
     .integerValue()
     .toString()
@@ -68,7 +42,7 @@ module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRa
     .pow(sellTokenReg.decimals)
     .times(sell.amount)
     .dividedBy(sellTokenReg.quantization)
-    .times(1 + (sellTokenReg.settleSpread || 0))
+    .times(1 + (settleSpreadSell || 0))
     .integerValue(BN.ROUND_DOWN)
     .toString()
 

--- a/lib/computeBuySellData.js
+++ b/lib/computeBuySellData.js
@@ -29,6 +29,9 @@ module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRa
   const sellTokenReg = getTokenInfo(sell.token)
   const buyTokenReg = getTokenInfo(buy.token)
 
+  // If Buy and Sell Amounts are for fill then first calculate
+  // the original order settle spread and use the same to calculate
+  // buy and sell amounts for the fill
   if (computeFill) {
     const orderBuyAmount = computeFill.amountBuy
     const orderSellAmount = computeFill.amountSell

--- a/lib/computeBuySellData.js
+++ b/lib/computeBuySellData.js
@@ -2,7 +2,7 @@ const BN = require('./BN')
 const splitSymbol = require('./splitSymbol')
 const toBN = require('./toBN')
 
-module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRate }) => {
+module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRate, computeFill }) => {
   amount = toBN(amount)
   price = toBN(price)
 
@@ -29,6 +29,29 @@ module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRa
   const sellTokenReg = getTokenInfo(sell.token)
   const buyTokenReg = getTokenInfo(buy.token)
 
+  if (computeFill) {
+    const orderBuyAmount = computeFill.amountBuy
+    const orderSellAmount = computeFill.amountSell
+
+    const buySettleSpread = toBN(orderBuyAmount)
+      .times(buyTokenReg.quantization)
+      .shiftedBy(-1 * buyTokenReg.decimals)
+      .dividedBy(buy.amount)
+      .dividedBy(1 - feeRate)
+      .minus(1)
+      .toNumber()
+
+    buyTokenReg.settleSpread = buySettleSpread
+
+    const sellSettleSpread = toBN(orderSellAmount)
+      .times(sellTokenReg.quantization)
+      .shiftedBy(-1 * sellTokenReg.decimals)
+      .dividedBy(sell.amount)
+      .minus(1)
+      .toNumber()
+
+    sellTokenReg.settleSpread = sellSettleSpread
+  }
   const amountBuy = toBN(10)
     .pow(buyTokenReg.decimals)
     .times(buy.amount)


### PR DESCRIPTION
Settle spread for a token will be updated in user-config when it is requested, this will result in settle spread being different for different orders.
The same settle spread needs to be used when calculating fills. To enable this computeBuySellData has been updated to accept buy and sell settlespread in order to calculate buy and sell amounts.