### PR TITLE
Reduce precision from 8 to 6 decimals

### DIFF
--- a/lib/prepareAmount.test.js
+++ b/lib/prepareAmount.test.js
@@ -15,15 +15,15 @@ const testValue = (priceIn, priceOut) => {
 }
 
 describe('prepareAmount', () => {
-  it('rounds provided number (or numeric string) to 8 decimal points, and returns it as a string', () => {
+  it('rounds provided number (or numeric string) to 6 decimal points, and returns it as a string', () => {
     testValue(1, '1')
     testValue(0.5, '0.5')
     testValue(0.6, '0.6')
-    testValue(0.00000001, '0.00000001')
+    testValue(0.000001, '0.000001')
     testValue(0.000000001, '0')
     testValue(0.000000004, '0')
-    testValue(0.000000005, '0.00000001')
-    testValue(0.000000006, '0.00000001')
-    testValue(1000000.000000006, '1000000.00000001')
+    testValue(0.0000005, '0.000001')
+    testValue(0.0000006, '0.000001')
+    testValue(1000000.0000006, '1000000.000001')
   })
 })

--- a/lib/prepareAmountBN.js
+++ b/lib/prepareAmountBN.js
@@ -1,6 +1,6 @@
 const BN = require('./BN')
 const toBN = require('./toBN')
-const DECIMAL_PLACES = 8
+const DECIMAL_PLACES = 6
 
 module.exports = price => toBN(price)
   .decimalPlaces(DECIMAL_PLACES, BN.ROUND_HALF_UP)


### PR DESCRIPTION
This is part of a fix for orders failing backend validation in some edge case scenarios.