### PR TITLE
Make amount decimal places configurable

### DIFF
--- a/lib/prepareAmount.js
+++ b/lib/prepareAmount.js
@@ -1,3 +1,4 @@
 const prepareAmountBN = require('./prepareAmountBN')
 
-module.exports = amount => prepareAmountBN(amount).toString()
+module.exports = (amount, DECIMAL_PLACES = 8) =>
+  prepareAmountBN(amount, DECIMAL_PLACES).toString()

--- a/lib/prepareAmount.test.js
+++ b/lib/prepareAmount.test.js
@@ -14,16 +14,30 @@ const testValue = (priceIn, priceOut) => {
   assertConsitentWithBfx(priceIn)
 }
 
+const testConfigurableDecimals = (amountIn, amountOut, decimalPlaces) => {
+  expect(prepareAmount(amountIn, decimalPlaces)).toBe(amountOut)
+}
+
 describe('prepareAmount', () => {
   it('rounds provided number (or numeric string) to 6 decimal points, and returns it as a string', () => {
     testValue(1, '1')
     testValue(0.5, '0.5')
     testValue(0.6, '0.6')
-    testValue(0.000001, '0.000001')
+    testValue(0.00000001, '0.00000001')
     testValue(0.000000001, '0')
     testValue(0.000000004, '0')
-    testValue(0.0000005, '0.000001')
-    testValue(0.0000006, '0.000001')
-    testValue(1000000.0000006, '1000000.000001')
+    testValue(0.000000005, '0.00000001')
+    testValue(0.000000006, '0.00000001')
+    testValue(1000000.000000006, '1000000.00000001')
+  })
+  it('decimal place precision can be configured', () => {
+    testConfigurableDecimals(1, '1', 6)
+    testConfigurableDecimals(0.5, '0.5', 6)
+    testConfigurableDecimals(0.6, '0.6', 6)
+    testConfigurableDecimals(0.00000001, '0', 6)
+    testConfigurableDecimals(0.000000001, '0', 6)
+    testConfigurableDecimals(0.000000004, '0', 6)
+    testConfigurableDecimals(0.0000005, '0.000001', 6)
+    testConfigurableDecimals(0.0000006, '0.000001', 6)
   })
 })

--- a/lib/prepareAmount.test.js
+++ b/lib/prepareAmount.test.js
@@ -15,15 +15,15 @@ const testValue = (priceIn, priceOut) => {
 }
 
 describe('prepareAmount', () => {
-  it('rounds provided number (or numeric string) to 8 decimal points, and returns it as a string', () => {
+  it('rounds provided number (or numeric string) to 6 decimal points, and returns it as a string', () => {
     testValue(1, '1')
     testValue(0.5, '0.5')
     testValue(0.6, '0.6')
-    testValue(0.00000001, '0.00000001')
+    testValue(0.000001, '0.000001')
     testValue(0.000000001, '0')
     testValue(0.000000004, '0')
-    testValue(0.000000005, '0.00000001')
-    testValue(0.000000006, '0.00000001')
-    testValue(1000000.000000006, '1000000.00000001')
+    testValue(0.0000005, '0.000001')
+    testValue(0.0000006, '0.000001')
+    testValue(1000000.0000006, '1000000.000001')
   })
 })

--- a/lib/prepareAmount.test.js
+++ b/lib/prepareAmount.test.js
@@ -17,9 +17,12 @@ const testValue = (priceIn, priceOut) => {
 const testConfigurableDecimals = (amountIn, amountOut, decimalPlaces) => {
   expect(prepareAmount(amountIn, decimalPlaces)).toBe(amountOut)
 }
+const testMaxDecimalsCorrection = (amountIn, amountOut, decimalPlaces) => {
+  expect(prepareAmount(amountIn, decimalPlaces)).toBe(amountOut)
+}
 
 describe('prepareAmount', () => {
-  it('rounds provided number (or numeric string) to 6 decimal points, and returns it as a string', () => {
+  it('rounds provided number (or numeric string) to 8 decimal points by default, and returns it as a string', () => {
     testValue(1, '1')
     testValue(0.5, '0.5')
     testValue(0.6, '0.6')
@@ -30,7 +33,7 @@ describe('prepareAmount', () => {
     testValue(0.000000006, '0.00000001')
     testValue(1000000.000000006, '1000000.00000001')
   })
-  it('decimal place precision can be configured', () => {
+  it('decimal place precision can be configuredn lower than 8', () => {
     testConfigurableDecimals(1, '1', 6)
     testConfigurableDecimals(0.5, '0.5', 6)
     testConfigurableDecimals(0.6, '0.6', 6)
@@ -39,5 +42,16 @@ describe('prepareAmount', () => {
     testConfigurableDecimals(0.000000004, '0', 6)
     testConfigurableDecimals(0.0000005, '0.000001', 6)
     testConfigurableDecimals(0.0000006, '0.000001', 6)
+  })
+  it('rounds provided number to max 8 decimal points if more than 8 was passed', () => {
+    testMaxDecimalsCorrection(1, '1', 10)
+    testMaxDecimalsCorrection(0.5, '0.5', 10)
+    testMaxDecimalsCorrection(0.6, '0.6', 10)
+    testMaxDecimalsCorrection(0.00000001, '0.00000001', 11)
+    testMaxDecimalsCorrection(0.000000001, '0', 12)
+    testMaxDecimalsCorrection(0.000000004, '0', 10)
+    testMaxDecimalsCorrection(0.000000005, '0.00000001', 11)
+    testMaxDecimalsCorrection(0.000000006, '0.00000001', 12)
+    testMaxDecimalsCorrection(1000000.000000006, '1000000.00000001', 12)
   })
 })

--- a/lib/prepareAmountBN.js
+++ b/lib/prepareAmountBN.js
@@ -1,5 +1,5 @@
 const BN = require('./BN')
 const toBN = require('./toBN')
 
-module.exports = (price, DECIMAL_PLACES = 8) => toBN(price)
-  .decimalPlaces(DECIMAL_PLACES, BN.ROUND_HALF_UP)
+module.exports = (price, DECIMAL_PLACES = 8) =>
+  toBN(price).decimalPlaces(Math.min(8, DECIMAL_PLACES), BN.ROUND_HALF_UP)

--- a/lib/prepareAmountBN.js
+++ b/lib/prepareAmountBN.js
@@ -1,6 +1,5 @@
 const BN = require('./BN')
 const toBN = require('./toBN')
-const DECIMAL_PLACES = 6
 
-module.exports = price => toBN(price)
+module.exports = (price, DECIMAL_PLACES = 8) => toBN(price)
   .decimalPlaces(DECIMAL_PLACES, BN.ROUND_HALF_UP)

--- a/lib/prepareAmountBN.js
+++ b/lib/prepareAmountBN.js
@@ -1,6 +1,6 @@
 const BN = require('./BN')
 const toBN = require('./toBN')
-const DECIMAL_PLACES = 8
+const DECIMAL_PLACES = 6
 
 module.exports = price => toBN(price)
   .decimalPlaces(DECIMAL_PLACES, BN.ROUND_HALF_UP)


### PR DESCRIPTION
- Restoring default precision of prepareAmount to 8 decimal places.
- prepareAmount uses a default value for decimal precision and can also use a passed value.