### PR TITLE
feat: add usdt mapping for comp, uni and yfi

### DIFF
--- a/config/config.js
+++ b/config/config.js
@@ -1,14 +1,23 @@
+/* eslint-disable quote-props */
 module.exports = {
   tokenMapping: {
     USDT: 'USD',
     USDC: 'UDC'
   },
   USDTMapping: {
+    // dvf to bfx
+    'tETHUSD': 'tETHUST',
+    'tBTCUSD': 'tBTCUST',
+    'tLINK:USD': 'tLINK:UST',
+    'tCOMP:USD': 'tCOMP:UST',
+    'tUNIUSD': 'tUNIUST',
+    'tYFIUSD': 'tYFIUST',
+    // bfx to dvf
     'ETH:UST': 'ETH:USDT',
     'BTC:UST': 'BTC:USDT',
     'LINK:UST': 'LINK:USDT',
-    tETHUSD: 'tETHUST',
-    tBTCUSD: 'tBTCUST',
-    'tLINK:USD': 'tLINK:UST'
+    'COMP:UST': 'COMP:USDT',
+    'UNI:UST': 'UNI:USDT',
+    'YFI:UST': 'YFI:USDT'
   }
 }

--- a/lib/bfxToDvfSymbol.test.js
+++ b/lib/bfxToDvfSymbol.test.js
@@ -1,20 +1,30 @@
 const bfxToDvfSymbol = require('dvf-utils/lib/bfxToDvfSymbol')
 
-const testValue = (dvf, bfx) => {
-  expect(bfxToDvfSymbol(dvf)).toBe(bfx)
+const testValue = (bfx, dvf) => {
+  expect(bfxToDvfSymbol(bfx)).toBe(dvf)
 }
 
+const testingPairs = [
+  ['tETHUST', 'ETH:USDT'],
+  ['tBTCUST', 'BTC:USDT'],
+  ['tUDCUSD', 'USDC:USDT'],
+  ['tZRXETH', 'ZRX:ETH'],
+  ['tZRXUSD', 'ZRX:USDT'],
+  ['tDUSK:BTC', 'DUSK:BTC'],
+  ['tDUSK:USD', 'DUSK:USDT'],
+  ['tOMGETH', 'OMG:ETH'],
+  ['tOMGUSD', 'OMG:USDT'],
+  ['tNECUSD', 'NEC:USDT'],
+  ['tLINK:UST', 'LINK:USDT'],
+  ['tCOMP:UST', 'COMP:USDT'],
+  ['tUNIUST', 'UNI:USDT'],
+  ['tYFIUST', 'YFI:USDT']
+]
+
 describe('bfxToDvfSymbol', () => {
-  it('converts Bitfinex trading symbol string to Deversifi trading symbol string', () => {
-    testValue('tETHUST', 'ETH:USDT')
-    testValue('tBTCUST', 'BTC:USDT')
-    testValue('tUDCUSD', 'USDC:USDT')
-    testValue('tZRXETH', 'ZRX:ETH')
-    testValue('tZRXUSD', 'ZRX:USDT')
-    testValue('tDUSK:BTC', 'DUSK:BTC')
-    testValue('tDUSK:USD', 'DUSK:USDT')
-    testValue('tOMGETH', 'OMG:ETH')
-    testValue('tOMGUSD', 'OMG:USDT')
-    testValue('tNECUSD', 'NEC:USDT')
+  testingPairs.forEach(([bfx, dvf]) => {
+    it(`converts Bitfinex trading symbol string (${bfx}) to Deversifi trading symbol string (${dvf})`, () => {
+      testValue(bfx, dvf)
+    })
   })
 })

--- a/lib/dvfToBfxSymbol.test.js
+++ b/lib/dvfToBfxSymbol.test.js
@@ -4,17 +4,27 @@ const testValue = (dvf, bfx) => {
   expect(dvfToBfxSymbol(dvf)).toBe(bfx)
 }
 
+const testingPairs = [
+  ['ETH:USDT', 'tETHUST'],
+  ['BTC:USDT', 'tBTCUST'],
+  ['USDC:USDT', 'tUDCUSD'],
+  ['ZRX:ETH', 'tZRXETH'],
+  ['ZRX:USDT', 'tZRXUSD'],
+  ['DUSK:BTC', 'tDUSK:BTC'],
+  ['DUSK:USDT', 'tDUSK:USD'],
+  ['OMG:ETH', 'tOMGETH'],
+  ['OMG:USDT', 'tOMGUSD'],
+  ['NEC:USDT', 'tNECUSD'],
+  ['LINK:USDT', 'tLINK:UST'],
+  ['COMP:USDT', 'tCOMP:UST'],
+  ['UNI:USDT', 'tUNIUST'],
+  ['YFI:USDT', 'tYFIUST']
+]
+
 describe('dvfToBfxSymbol', () => {
-  it('converts Deversifi trading symbol string to Bitfinex trading symbol string', () => {
-    testValue('ETH:USDT', 'tETHUST')
-    testValue('BTC:USDT', 'tBTCUST')
-    testValue('USDC:USDT', 'tUDCUSD')
-    testValue('ZRX:ETH', 'tZRXETH')
-    testValue('ZRX:USDT', 'tZRXUSD')
-    testValue('DUSK:BTC', 'tDUSK:BTC')
-    testValue('DUSK:USDT', 'tDUSK:USD')
-    testValue('OMG:ETH', 'tOMGETH')
-    testValue('OMG:USDT', 'tOMGUSD')
-    testValue('NEC:USDT', 'tNECUSD')
+  testingPairs.forEach(([dvf, bfx]) => {
+    it(`converts Deversifi trading symbol string (${dvf}) to Bitfinex trading symbol string (${bfx})`, () => {
+      testValue(dvf, bfx)
+    })
   })
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-utils",
-  "version": "0.1.4",
+  "version": "0.1.5",
   "description": "utils shared between client and backend",
   "main": "index.js",
   "repository": "git@github.com:DeversiFi/dvf-utils.git",


### PR DESCRIPTION
@plutoegg the way this was made makes a little harder to do a reverse mapping on `USDTMapping` like it can be made on `tokenMapping`, the only thing I could do was to make it more organised with some sort of separation
https://github.com/DeversiFi/dvf-utils/pull/12/files#diff-a7c4d97b958033f33a08e9247c6619d20e47465301a5aea82088fcce7b936c5bR15

Also updated the tests to be more readable when run.