### PR TITLE
prepareAmount: revet to using ROUND_HALF_UP by default

### DIFF
--- a/lib/prepareAmount.js
+++ b/lib/prepareAmount.js
@@ -1,4 +1,4 @@
 const prepareAmountBN = require('./prepareAmountBN')
 
-module.exports = (amount, DECIMAL_PLACES = 8) =>
-  prepareAmountBN(amount, DECIMAL_PLACES).toString()
+module.exports = (amount, decimalPlaces, roundingMethod) =>
+  prepareAmountBN(amount, decimalPlaces, roundingMethod).toString()

--- a/lib/prepareAmount.test.js
+++ b/lib/prepareAmount.test.js
@@ -14,8 +14,8 @@ const testValue = (priceIn, priceOut) => {
   assertConsitentWithBfx(priceIn)
 }
 
-const testConfigurableDecimals = (amountIn, amountOut, decimalPlaces) => {
-  expect(prepareAmount(amountIn, decimalPlaces)).toBe(amountOut)
+const testConfigurableDecimals = (amountIn, amountOut, decimalPlaces, rounding) => {
+  expect(prepareAmount(amountIn, decimalPlaces, rounding)).toBe(amountOut)
 }
 const testMaxDecimalsCorrection = (amountIn, amountOut, decimalPlaces) => {
   expect(prepareAmount(amountIn, decimalPlaces)).toBe(amountOut)
@@ -27,21 +27,27 @@ describe('prepareAmount', () => {
     testValue(0.5, '0.5')
     testValue(0.6, '0.6')
     testValue(0.00000001, '0.00000001')
+    testValue(0.000000001, '0')
     testValue(0.000000004, '0')
-    testValue(0.000000014, '0.00000001')
-    testValue(0.000000015, '0.00000001')
-    testValue(0.000000014, '0.00000001')
-    testValue(1000000.000000024, '1000000.00000002')
+    testValue(0.000000005, '0.00000001')
+    testValue(0.000000006, '0.00000001')
+    testValue(1000000.000000006, '1000000.00000001')
   })
-  it('decimal place precision can be configuredn lower than 8', () => {
+  it('decimal place precision can be configured lower than 8', () => {
     testConfigurableDecimals(1, '1', 6)
     testConfigurableDecimals(0.5, '0.5', 6)
     testConfigurableDecimals(0.6, '0.6', 6)
     testConfigurableDecimals(0.00000001, '0', 6)
     testConfigurableDecimals(0.000000001, '0', 6)
     testConfigurableDecimals(0.000000004, '0', 6)
-    testConfigurableDecimals(0.0000014, '0.000001', 6)
-    testConfigurableDecimals(0.0000016, '0.000001', 6)
+    testConfigurableDecimals(0.0000005, '0.000001', 6)
+    testConfigurableDecimals(0.0000006, '0.000001', 6)
+  })
+  it('rounding method can be configured', () => {
+    testConfigurableDecimals(0.000000001, '0', 8, BN.ROUND_FLOOR)
+    testConfigurableDecimals(0.000000001, '0.00000001', 8, BN.ROUND_CEIL)
+    testConfigurableDecimals(1000000.000000006, '1000000', 8, BN.ROUND_FLOOR)
+    testConfigurableDecimals(1000000.000000006, '1000000.00000001', 8, BN.ROUND_CEIL)
   })
   it('rounds provided number to max 8 decimal points if more than 8 was passed', () => {
     testMaxDecimalsCorrection(1, '1', 10)
@@ -50,8 +56,8 @@ describe('prepareAmount', () => {
     testMaxDecimalsCorrection(0.00000001, '0.00000001', 11)
     testMaxDecimalsCorrection(0.000000001, '0', 12)
     testMaxDecimalsCorrection(0.000000004, '0', 10)
-    testMaxDecimalsCorrection(0.000000015, '0.00000001', 11)
-    testMaxDecimalsCorrection(0.000000018, '0.00000001', 12)
-    testMaxDecimalsCorrection(1000000.000000014, '1000000.00000001', 12)
+    testMaxDecimalsCorrection(0.000000005, '0.00000001', 11)
+    testMaxDecimalsCorrection(0.000000006, '0.00000001', 12)
+    testMaxDecimalsCorrection(1000000.000000006, '1000000.00000001', 12)
   })
 })

--- a/lib/prepareAmountBN.js
+++ b/lib/prepareAmountBN.js
@@ -1,5 +1,13 @@
 const BN = require('./BN')
 const toBN = require('./toBN')
 
-module.exports = (price, DECIMAL_PLACES = 8) =>
-  toBN(price).decimalPlaces(Math.min(8, DECIMAL_PLACES), BN.ROUND_FLOOR)
+const defaultAndMaxDecimalPlaces = 8
+
+module.exports = (
+  price,
+  decimalPlaces = defaultAndMaxDecimalPlaces,
+  roundingMethod = BN.ROUND_HALF_UP
+) => toBN(price).decimalPlaces(
+  Math.min(defaultAndMaxDecimalPlaces, decimalPlaces),
+  roundingMethod
+)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-utils",
-  "version": "0.1.5",
+  "version": "0.2.0",
   "description": "utils shared between client and backend",
   "main": "index.js",
   "repository": "git@github.com:DeversiFi/dvf-utils.git",


### PR DESCRIPTION
and allow it to be configured see discussion here:
https://github.com/DeversiFi/dvf-utils/commit/bdcf7b9699831d3101a05a79014e0b2de11ce6b0#r43401504