### PR TITLE
add Joi.long type (64 bit signed int) and bigNumber type

### DIFF
--- a/lib/Joi.js
+++ b/lib/Joi.js
@@ -4,6 +4,7 @@ const web3Utils = require('web3-utils')
 const prepareAmount = require('./prepareAmount')
 const preparePrice = require('./preparePrice')
 const toBN = require('./toBN')
+const BN = require('./BN')
 const toBigInt = require('./toBigInt')
 const isLong = require('./isLong')
 const toLong = require('./toLong')
@@ -118,7 +119,7 @@ module.exports = Joi
           if (minimum == null) {
             throw new Error('minimum arg cannot be nullish')
           }
-          return this.$_addRule({ name: 'min', args: { minimum } })
+          return this.$_addRule({ name: 'min', args: { minimum: toLong(minimum) } })
         },
         args: [
           {
@@ -136,7 +137,7 @@ module.exports = Joi
           if (maximum == null) {
             throw new Error('maximum arg cannot be nullish')
           }
-          return this.$_addRule({ name: 'max', args: { maximum } })
+          return this.$_addRule({ name: 'max', args: { maximum: toLong(maximum) } })
         },
         args: [
           {
@@ -148,6 +149,65 @@ module.exports = Joi
         validate: (value, helpers, args, options) => value.lessThanOrEqual(args.maximum)
           ? value
           : helpers.error('long.max', { maximum: args.maximum })
+      }
+    }
+  }))
+  .extend(Joi => ({
+    base: Joi.any(),
+    type: 'bigNumber',
+    messages: {
+      'bigNumber.base': '{{#label}} must be of type (or unambiguously coercible to) BigNumber',
+      'bigNumber.min': '{{#label}} must be >= {{#minimum}}',
+      'bigNumber.max': '{{#label}} must be <= {{#maximum}}'
+    },
+    coerce: (value, helpers) => {
+      try {
+        return { value: toBN(value) }
+      } catch (error) {
+        return { value }
+      }
+    },
+    validate: (value, helpers) => {
+      if (!(BN.isBigNumber(value))) {
+        return { value, errors: helpers.error('bigNumber.base') }
+      }
+    },
+    rules: {
+      min: {
+        method (minimum) {
+          if (minimum == null) {
+            throw new Error('minimum arg cannot be nullish')
+          }
+          return this.$_addRule({ name: 'min', args: { minimum: toBN(minimum) } })
+        },
+        args: [
+          {
+            name: 'minimum',
+            assert: value => BN.isBigNumber(value),
+            message: 'must be a Long'
+          }
+        ],
+        validate: (value, helpers, args, options) => value.isGreaterThanOrEqualTo(args.minimum)
+          ? value
+          : helpers.error('bigNumber.min', { minimum: args.minimum })
+      },
+      max: {
+        method (maximum) {
+          if (maximum == null) {
+            throw new Error('maximum arg cannot be nullish')
+          }
+          return this.$_addRule({ name: 'max', args: { maximum: toBN(maximum) } })
+        },
+        args: [
+          {
+            name: 'maximum',
+            assert: value => BN.isBigNumber(value),
+            message: 'must be a Long'
+          }
+        ],
+        validate: (value, helpers, args, options) => value.isLessThanOrEqualTo(args.maximum)
+          ? value
+          : helpers.error('bigNumber.max', { maximum: args.maximum })
       }
     }
   }))

--- a/lib/Joi.js
+++ b/lib/Joi.js
@@ -158,7 +158,9 @@ module.exports = Joi
     messages: {
       'bigNumber.base': '{{#label}} must be of type (or unambiguously coercible to) BigNumber',
       'bigNumber.min': '{{#label}} must be >= {{#minimum}}',
-      'bigNumber.max': '{{#label}} must be <= {{#maximum}}'
+      'bigNumber.max': '{{#label}} must be <= {{#maximum}}',
+      'bigNumber.greaterThan': '{{#label}} must be > {{#exclusiveMinimum}}',
+      'bigNumber.lessThan': '{{#label}} must be < {{#exclusiveMaximum}}'
     },
     coerce: (value, helpers) => {
       try {
@@ -208,6 +210,43 @@ module.exports = Joi
         validate: (value, helpers, args, options) => value.isLessThanOrEqualTo(args.maximum)
           ? value
           : helpers.error('bigNumber.max', { maximum: args.maximum })
+      },
+      greaterThan: {
+        method (exclusiveMinimum) {
+          console.log('exclusiveMinimum', exclusiveMinimum)
+          if (exclusiveMinimum == null) {
+            throw new Error('exclusiveMinimum arg cannot be nullish')
+          }
+          return this.$_addRule({ name: 'greaterThan', args: { exclusiveMinimum: toBN(exclusiveMinimum) } })
+        },
+        args: [
+          {
+            name: 'exclusiveMinimum',
+            assert: value => BN.isBigNumber(value),
+            message: 'must be a Long'
+          }
+        ],
+        validate: (value, helpers, args, options) => value.isGreaterThan(args.exclusiveMinimum)
+          ? value
+          : helpers.error('bigNumber.greaterThan', { exclusiveMinimum: args.exclusiveMinimum })
+      },
+      lessThan: {
+        method (exclusiveMaximum) {
+          if (exclusiveMaximum == null) {
+            throw new Error('exclusiveMaximum arg cannot be nullish')
+          }
+          return this.$_addRule({ name: 'lessThan', args: { exclusiveMaximum: toBN(exclusiveMaximum) } })
+        },
+        args: [
+          {
+            name: 'exclusiveMaximum',
+            assert: value => BN.isBigNumber(value),
+            message: 'must be a Long'
+          }
+        ],
+        validate: (value, helpers, args, options) => value.isLessThan(args.exclusiveMaximum)
+          ? value
+          : helpers.error('bigNumber.lessThan', { exclusiveMaximum: args.exclusiveMaximum })
       }
     }
   }))

--- a/lib/Joi.js
+++ b/lib/Joi.js
@@ -5,6 +5,8 @@ const prepareAmount = require('./prepareAmount')
 const preparePrice = require('./preparePrice')
 const toBN = require('./toBN')
 const toBigInt = require('./toBigInt')
+const isLong = require('./isLong')
+const toLong = require('./toLong')
 
 module.exports = Joi
   .extend(Joi => ({
@@ -87,6 +89,65 @@ module.exports = Joi
     validate: (value, helpers) => {
       if (!(typeof value === 'bigint')) {
         return { value, errors: helpers.error('amount.base') }
+      }
+    }
+  }))
+  .extend(Joi => ({
+    base: Joi.any(),
+    type: 'long',
+    messages: {
+      'long.base': '{{#label}} must be of type (or unambiguously coercible to) Long (64 bit signed integer)',
+      'long.min': '{{#label}} must be >= {{#minimum}}',
+      'long.max': '{{#label}} must be <= {{#maximum}}'
+    },
+    coerce: (value, helpers) => {
+      try {
+        return { value: toLong(value) }
+      } catch (error) {
+        return { value }
+      }
+    },
+    validate: (value, helpers) => {
+      if (!(isLong(value))) {
+        return { value, errors: helpers.error('long.base') }
+      }
+    },
+    rules: {
+      min: {
+        method (minimum) {
+          if (minimum == null) {
+            throw new Error('minimum arg cannot be nullish')
+          }
+          return this.$_addRule({ name: 'min', args: { minimum } })
+        },
+        args: [
+          {
+            name: 'minimum',
+            assert: value => isLong(value),
+            message: 'must be a Long'
+          }
+        ],
+        validate: (value, helpers, args, options) => value.greaterThanOrEqual(args.minimum)
+          ? value
+          : helpers.error('long.min', { minimum: args.minimum })
+      },
+      max: {
+        method (maximum) {
+          if (maximum == null) {
+            throw new Error('maximum arg cannot be nullish')
+          }
+          return this.$_addRule({ name: 'max', args: { maximum } })
+        },
+        args: [
+          {
+            name: 'maximum',
+            assert: value => isLong(value),
+            message: 'must be a Long'
+          }
+        ],
+        validate: (value, helpers, args, options) => value.lessThanOrEqual(args.maximum)
+          ? value
+          : helpers.error('long.max', { maximum: args.maximum })
       }
     }
   }))

--- a/lib/Joi.test.js
+++ b/lib/Joi.test.js
@@ -1,4 +1,10 @@
 const Joi = require('./Joi')
+const toLong = require('./toLong')
+const toBN = require('./toBN')
+
+const testErrorMessage = schema => message => value => expect(
+  schema.validate(value).error
+).toHaveProperty('message', message)
 
 describe('Joi', () => {
   it('ethAddress', () => {
@@ -18,25 +24,74 @@ describe('Joi', () => {
       expect(schema.validate(value)).toEqual({ value })
     })
 
-    const testErrorMessage = message => value => expect(
-      schema.validate(value).error
-    ).toHaveProperty('message', message)
+    const testError = testErrorMessage(schema)
 
-    testErrorMessage('"value" is not allowed to be empty')('')
+    testError('"value" is not allowed to be empty')('')
 
-    testErrorMessage('"value" is required')(undefined)
+    testError('"value" is required')(undefined)
 
     ;[
       null,
       0,
       {},
       []
-    ].forEach(testErrorMessage('"value" must be a string'))
+    ].forEach(testError('"value" must be a string'))
 
     ;[
       'abc',
       '0xCc6E2d20cC5AaFDCa329bA2d63e5ba5edD684B2f',
       `${validChecksumAddress}0}`
-    ].forEach(testErrorMessage('"value" must be a valid Ethereum Address'))
+    ].forEach(testError('"value" must be a valid Ethereum Address'))
+  })
+
+  describe('long', () => {
+    const schema = Joi.long().required()
+
+    const testValid = schema => value => {
+      expect(schema.validate(value)).toEqual({ value: toLong(value) })
+    }
+
+    it('accepts values of mongodb.Long type or ones which can be unambiguously coerced to it', () => {
+      expect.assertions(7 + 1 + 4)
+
+      ;[
+        -1,
+        '-1',
+        0,
+        toLong(0),
+        toLong(Number.MAX_SAFE_INTEGER).add(toLong(1)),
+        toBN(Number.MAX_SAFE_INTEGER).plus(1),
+        Number.MAX_SAFE_INTEGER
+      ].forEach(testValid(schema))
+
+      const testError = testErrorMessage(schema)
+
+      testError('"value" is required')(undefined)
+
+      ;[
+        null,
+        {},
+        [],
+        ''
+      ].forEach(testError('"value" must be of type (or unambiguously coercible to) Long (64 bit signed integer)'))
+    })
+
+    it('respects min modifier', () => {
+      expect.assertions(2 + 2)
+
+      const schemaMin = schema.min(toLong(1))
+      ;[1, '2'].forEach(testValid(schemaMin))
+
+      ;[0, '-1'].forEach(testErrorMessage(schemaMin)('"value" must be >= 1'))
+    })
+
+    it('respects max modifier', () => {
+      expect.assertions(2 + 2)
+
+      const schemaMin = schema.max(toLong(1))
+      ;[0, '1'].forEach(testValid(schemaMin))
+
+      ;[2, '3'].forEach(testErrorMessage(schemaMin)('"value" must be <= 1'))
+    })
   })
 })

--- a/lib/Joi.test.js
+++ b/lib/Joi.test.js
@@ -145,5 +145,23 @@ describe('Joi', () => {
 
       ;[2, '3'].forEach(testErrorMessage(schemaMax)('"value" must be <= 1'))
     })
+
+    it('respects greaterThan modifier', () => {
+      expect.assertions(2 + 2)
+
+      const schemaGreaterThan = schema.greaterThan(1)
+      ;[2, '3'].forEach(testValid(schemaGreaterThan))
+
+      ;[1, '0'].forEach(testErrorMessage(schemaGreaterThan)('"value" must be > 1'))
+    })
+
+    it('respects lessThan modifier', () => {
+      expect.assertions(2 + 2)
+
+      const schemaLessThan = schema.lessThan(toBN(1))
+      ;[-1, '0'].forEach(testValid(schemaLessThan))
+
+      ;[1, '2'].forEach(testErrorMessage(schemaLessThan)('"value" must be < 1'))
+    })
   })
 })

--- a/lib/Joi.test.js
+++ b/lib/Joi.test.js
@@ -1,5 +1,6 @@
 const Joi = require('./Joi')
 const toLong = require('./toLong')
+const Long = require('./Long')
 const toBN = require('./toBN')
 
 const testErrorMessage = schema => message => value => expect(
@@ -88,10 +89,61 @@ describe('Joi', () => {
     it('respects max modifier', () => {
       expect.assertions(2 + 2)
 
-      const schemaMin = schema.max(toLong(1))
-      ;[0, '1'].forEach(testValid(schemaMin))
+      const schemaMax = schema.max(1)
+      ;[0, '1'].forEach(testValid(schemaMax))
 
-      ;[2, '3'].forEach(testErrorMessage(schemaMin)('"value" must be <= 1'))
+      ;[2, '3'].forEach(testErrorMessage(schemaMax)('"value" must be <= 1'))
+    })
+  })
+
+  describe('bigNumber', () => {
+    const schema = Joi.bigNumber().required()
+
+    const testValid = schema => value => {
+      expect(schema.validate(value)).toEqual({ value: toBN(value) })
+    }
+
+    it('accepts values of mongodb.Long type or ones which can be unambiguously coerced to it', () => {
+      expect.assertions(7 + 1 + 4)
+
+      ;[
+        -1,
+        '-1',
+        0,
+        toBN(0),
+        toBN(Number.MAX_VALUE).plus(toBN(1)),
+        Long.MAX_VALUE,
+        Number.MAX_VALUE
+      ].forEach(testValid(schema))
+
+      const testError = testErrorMessage(schema)
+
+      testError('"value" is required')(undefined)
+
+      ;[
+        null,
+        {},
+        [],
+        ''
+      ].forEach(testError('"value" must be of type (or unambiguously coercible to) BigNumber'))
+    })
+
+    it('respects min modifier', () => {
+      expect.assertions(2 + 2)
+
+      const schemaMin = schema.min(1)
+      ;[1, '2'].forEach(testValid(schemaMin))
+
+      ;[0, '-1'].forEach(testErrorMessage(schemaMin)('"value" must be >= 1'))
+    })
+
+    it('respects max modifier', () => {
+      expect.assertions(2 + 2)
+
+      const schemaMax = schema.max(toBN(1))
+      ;[0, '1'].forEach(testValid(schemaMax))
+
+      ;[2, '3'].forEach(testErrorMessage(schemaMax)('"value" must be <= 1'))
     })
   })
 })

--- a/lib/Long.js
+++ b/lib/Long.js
@@ -1,0 +1,1 @@
+module.exports = require('bson').Long

--- a/lib/index.js
+++ b/lib/index.js
@@ -3,12 +3,14 @@ module.exports = {
   BfxToDvfToken: require('./BfxToDvfToken'),
   DvfToBfxToken: require('./DvfToBfxToken'),
   Joi: require('./Joi'),
+  Long: require('./Long'),
   MapUSDTSymbol: require('./MapUSDTSymbol'),
   bfxSymbolToDvfSymbol: require('./bfxSymbolToDvfSymbol'),
   bfxToDvfSymbol: require('./bfxToDvfSymbol'),
   computeBuySellData: require('./computeBuySellData'),
   dvfToBfxSymbol: require('./dvfToBfxSymbol'),
   fromQuantizedToBaseUnitsBN: require('./fromQuantizedToBaseUnitsBN'),
+  isLong: require('./isLong'),
   mapJoiSchemaKeysToCamelCaseRecursive: require('./mapJoiSchemaKeysToCamelCaseRecursive'),
   mapKeysRecursiveWith: require('./mapKeysRecursiveWith'),
   prepareAmount: require('./prepareAmount'),
@@ -19,6 +21,7 @@ module.exports = {
   starkTransferTxToMessageHash: require('./starkTransferTxToMessageHash'),
   toBN: require('./toBN'),
   toBigInt: require('./toBigInt'),
+  toLong: require('./toLong'),
   toQuantizedAmountBN: require('./toQuantizedAmountBN'),
   toQuantizedAmountString: require('./toQuantizedAmountString')
 }

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ module.exports = {
   MapUSDTSymbol: require('./MapUSDTSymbol'),
   bfxSymbolToDvfSymbol: require('./bfxSymbolToDvfSymbol'),
   bfxToDvfSymbol: require('./bfxToDvfSymbol'),
+  calculateStarkTransferCondition: require('./calculateStarkTransferCondition'),
   computeBuySellData: require('./computeBuySellData'),
   dvfToBfxSymbol: require('./dvfToBfxSymbol'),
   fromQuantizedToBaseUnitsBN: require('./fromQuantizedToBaseUnitsBN'),

--- a/lib/isLong.js
+++ b/lib/isLong.js
@@ -1,0 +1,3 @@
+const Long = require('./Long')
+
+module.exports = v => v instanceof Long || (v != null && v._bsontype === 'Long')

--- a/lib/toLong.js
+++ b/lib/toLong.js
@@ -1,0 +1,44 @@
+const Long = require('./Long')
+
+const isLong = require('./isLong')
+
+const isNumber = v => v instanceof Number || typeof v === 'number'
+const isString = v => v instanceof String || typeof v === 'string'
+
+const maxLongValueAsBigInt = BigInt(Long.MAX_VALUE)
+const minLongValueAsBigInt = BigInt(Long.MIN_VALUE)
+
+const fromString = value => {
+  const result = Long.fromString(value)
+  if (result.toString() !== value) {
+    throw new Error(`ivalid Long string value: ${value}, converts to: ${result}`)
+  }
+  return result
+}
+
+module.exports = (value) => {
+  if (isLong(value)) return value
+
+  if (isNumber(value)) return Long.fromNumber(value)
+
+  if (isString(value)) {
+    return fromString(value)
+  }
+
+  if (typeof value === 'bigint') {
+    if (value >= minLongValueAsBigInt && value <= maxLongValueAsBigInt) {
+      return Long.fromString(value.toString())
+    } else {
+      throw new Error(
+        'cannot convert provided BigInt value to Long, ' +
+        `as its out of range, value: ${value}`
+      )
+    }
+  }
+
+  if (value.toString) {
+    return fromString(value.toString())
+  }
+
+  throw new Error(`cannot convert given value to Long, value: ${value}`)
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   "dependencies": {
     "@hapi/joi": "^17.1.1",
     "bignumber.js": "^9.0.0",
+    "bson": "^1.1.5",
     "ramda": "^0.27.1",
     "web3-utils": "^1.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-utils",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "utils shared between client and backend",
   "main": "lib/index.js",
   "repository": "git@github.com:DeversiFi/dvf-utils.git",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1469,6 +1469,11 @@ bser@2.1.1:
   dependencies:
     node-int64 "^0.4.0"
 
+bson@^1.1.5:
+  version "1.1.5"
+  resolved "https://registry.yarnpkg.com/bson/-/bson-1.1.5.tgz#2aaae98fcdf6750c0848b0cba1ddec3c73060a34"
+  integrity sha512-kDuEzldR21lHciPQAIulLs1LZlCXdLziXI6Mb/TDkwXhb//UORJNPXgcRs2CuO4H0DcMkpfT3/ySsP3unoZjBg==
+
 buffer-from@^1.0.0:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/buffer-from/-/buffer-from-1.1.1.tgz#32713bc028f75c02fdb710d7c7bcec1f2c6070ef"


### PR DESCRIPTION
Joi.long: accepts any value which can be unambiguously converted to bson.Long (used by mongodb)
Joi.bigNumber: accepts any value which can be unambiguously converted to `BigNumber` (from `bignumber.js`)

also adds:
- reexport bson.Long
- add isLong and toLong helpers (copied from backend repo)