### PR TITLE
Joi: Adding prefixedHexString validation

### DIFF
--- a/lib/Joi.js
+++ b/lib/Joi.js
@@ -11,6 +11,13 @@ const toLong = require('./toLong')
 
 module.exports = Joi
   .extend(Joi => ({
+    base: Joi.string().pattern(/^0x[a-f0-9]+$/i),
+    type: 'prefixedHexString',
+    messages: {
+      'string.pattern.base': '{{#label}} must be a valid 0x-prefixed hex string'
+    }
+  }))
+  .extend(Joi => ({
     base: Joi.string(),
     type: 'ethAddress',
     messages: {

--- a/lib/Joi.test.js
+++ b/lib/Joi.test.js
@@ -8,6 +8,33 @@ const testErrorMessage = schema => message => value => expect(
 ).toHaveProperty('message', message)
 
 describe('Joi', () => {
+  it('prefixedHexString', () => {
+    const validHexString = '0x0180fc633b754b50370614a587218cf36a4fa7c2f11d65ec761dded48a81ab9e'
+
+    const schema = Joi.prefixedHexString().required()
+
+    expect(schema.validate(validHexString)).toEqual({ value: validHexString })
+
+    const testError = testErrorMessage(schema)
+
+    testError('"value" is not allowed to be empty')('')
+
+    testError('"value" is required')(undefined)
+
+    ;[
+      null,
+      0,
+      {},
+      []
+    ].forEach(testError('"value" must be a string'))
+
+    ;[
+      'abc',
+      '0x1818*9-2',
+      `1x${validHexString}}`
+    ].forEach(testError('"value" must be a valid 0x-prefixed hex string'))
+  })
+
   it('ethAddress', () => {
     const validChecksumAddress = '0xCc6E2d20cC5AaFDCa329bA2d63e5ba5edD684B2F'
 


### PR DESCRIPTION
Adding prefixedHexString to this common lib as it is starting to be used in different places (for example to validate 0x-prefixed stark public keys)