### PR TITLE
re-apply prepareAmountBN after operations

### DIFF
--- a/lib/computeBuySellData.js
+++ b/lib/computeBuySellData.js
@@ -1,13 +1,14 @@
 const BN = require('./BN')
+const prepareAmountBN = require('./prepareAmountBN')
+const preparePriceBN = require('./preparePriceBN')
 const splitSymbol = require('./splitSymbol')
 const toBN = require('./toBN')
 
 module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRate, settleSpreadBuy, settleSpreadSell }) => {
-  amount = toBN(amount)
-  price = toBN(price)
-
+  amount = prepareAmountBN(amount)
+  price = preparePriceBN(price)
   if (amount.isEqualTo(0)) throw new DVFError('AMOUNT_CANNOT_BE_ZERO')
-  if (price.isLessThan(0)) throw new DVFError('PRICE_MUST_BE_POSITIVE')
+  if (price.isLessThanOrEqualTo(0)) throw new DVFError('PRICE_MUST_BE_POSITIVE')
 
   const [baseToken, quoteToken] = splitSymbol(symbol)
   const absAmount = amount.absoluteValue()
@@ -19,7 +20,7 @@ module.exports = ({ DVFError, getTokenInfo }) => ({ symbol, amount, price, feeRa
 
   const quote = {
     token: quoteToken,
-    amount: absAmount.times(price)
+    amount: prepareAmountBN(absAmount.times(price))
   }
 
   const [buy, sell] = amount.isGreaterThan(0)


### PR DESCRIPTION
Ensures that prices and amounts are correctly rounded when processed.

Consistent with : https://github.com/DeversiFi/launch-deversifi/pull/1154