### PR TITLE
configure jest to test with both node and jsdom environments

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,12 @@
+module.exports = {
+  projects: [
+    {
+      displayName: 'browser',
+      testEnvironment: 'jsdom'
+    },
+    {
+      displayName: 'node',
+      testEnvironment: 'node'
+    }
+  ]
+}

--- a/lib/request.test.js
+++ b/lib/request.test.js
@@ -143,16 +143,9 @@ describe('Request Tests', () => {
       nock.enableNetConnect()
     })
 
-    // Currently Jest/JSDom hooks into http client and logs errors
-    // to the console, we are not using JSDom at all but in Jest
-    // v26.x default testEnvironment is 'jsdom' - in Jest v27.x
-    // default testEnvironment is 'node'.
-    //
-    // Test below works (with disable/enable in before/after) but
-    // kicks up an error with jsDom environment.
-    //
-    // Skip until we decide to switch to node for test env.
-    it.skip('fails with RequestError for no response', () => {
+    // Test below works but logs an error with jsDom environment.
+    // TODO: submit an issue on nock's repo.
+    it('fails with RequestError for no response', () => {
       return expect(request.get(`${apiDomain}${getTest.url}`))
         .rejects.toThrow(RequestError)
     })


### PR DESCRIPTION
and unskip test which logs an error when ran with jests jsdom env
it logs an error but it doesn't fail