### PR TITLE
[JUP-388]: change auth message to rhino.fi

### DIFF
--- a/lib/generateAuthMessageForAuthVersion.js
+++ b/lib/generateAuthMessageForAuthVersion.js
@@ -9,7 +9,8 @@ module.exports = (nonce, authVersion) => {
     case 3:
     {
       const formattedUTCDate = new Date(nonce * 1000).toUTCString()
-      return `Signing in on ${formattedUTCDate}. For your safety, only sign this message on rhino.fi!`.toString(16)
+      return `To protect your rhino.fi privacy we ask you to sign in with your wallet to see your data.
+Signing in on ${formattedUTCDate}. For your safety, only sign this message on rhino.fi!`.toString(16)
     }
     default:
       // Original authentication method where raw nonce was signed

--- a/lib/generateAuthMessageForAuthVersion.js
+++ b/lib/generateAuthMessageForAuthVersion.js
@@ -9,7 +9,7 @@ module.exports = (nonce, authVersion) => {
     case 3:
     {
       const formattedUTCDate = new Date(nonce * 1000).toUTCString()
-      return `Signing in to rhino.fi on ${formattedUTCDate}. For your safety, only sign this message on rhino.fi.`.toString(16)
+      return `Signing in on ${formattedUTCDate}. For your safety, only sign this message on rhino.fi!`.toString(16)
     }
     default:
       // Original authentication method where raw nonce was signed

--- a/lib/generateAuthMessageForAuthVersion.js
+++ b/lib/generateAuthMessageForAuthVersion.js
@@ -6,6 +6,11 @@ module.exports = (nonce, authVersion) => {
       const formattedUTCDate = new Date(nonce * 1000).toUTCString()
       return `Signing in to DeversiFi on ${formattedUTCDate}. For your safety, only sign this message on DeversiFi.`.toString(16)
     }
+    case 3:
+    {
+      const formattedUTCDate = new Date(nonce * 1000).toUTCString()
+      return `Signing in to rhino.fi on ${formattedUTCDate}. For your safety, only sign this message on rhino.fi.`.toString(16)
+    }
     default:
       // Original authentication method where raw nonce was signed
       return nonce.toString().toString(16)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dvf-utils",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "description": "utils shared between client and backend",
   "main": "lib/index.js",
   "repository": "git@github.com:DeversiFi/dvf-utils.git",


### PR DESCRIPTION
For reband, we need to change the message being signed for authentication

Once this is merged, `authVersion` should be bumped here: https://github.com/DeversiFi/launch-deversifi/pull/2842